### PR TITLE
Add GPU profile and additional checks to standard profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,16 +63,27 @@ Validator](https://github.com/DMTF/Redfish-Interop-Validator).
    EOF
    ```
 ## Execute the Redfish Interop Validator
-1. Set PASSWD and ENDPOINT variables.
+1. Set environment variables.
    ```
    # read -s PASSWD
    <enter redfish root password>
    # ENDPOINT=<hostname or IP>
    ```
-1. Execute the Redfish Interop Validator.
+1. Select which profile to use
+   * Standard node
+      ```
+      # PROFILE="../redfish-validator-profiles/profiles/CSMRedfishProfile.v1_2_0.json"
+      ```
+   * Node with GPUs
+      ```
+      # PROFILE="../redfish-validator-profiles/profiles/CSMRedfishProfile-GPU.v1_0_0.json"
+      ```
+      * This profile will indicate a ProcessorType failure with non-GPUs. These
+      errors can safely be ignored. 
+2. Execute the Redfish Interop Validator.
    ```
-   # python3 RedfishInteropValidator.py -c config/CSM.ini -i https://$ENDPOINT ../redfish-validator-profiles/profiles/CSMRedfishProfile.v1_1_0.json -p $PASSWD
+   # python3 RedfishInteropValidator.py -c config/CSM.ini -i https://$ENDPOINT $PROFILE -p $PASSWD
    ```
    Execution time is hardware dependent
-2. A summary is displayed at the end of the execution. A **.txt** and **.html**
+3. A summary is displayed at the end of the execution. A **.txt** and **.html**
 file are also created in the **logs** directory for further analysis.

--- a/profiles/CSMRedfishProfile-GPU.v1_0_0.json
+++ b/profiles/CSMRedfishProfile-GPU.v1_0_0.json
@@ -1,0 +1,573 @@
+{
+	"SchemaDefinition": "RedfishInteroperabilityProfile.v1_5_0",
+	"ProfileName": "CSMRedfishProfile-GPU",
+	"ProfileVersion": "1.0.0",
+	"OwningEntity": "Hewlet Packard Enterprise Development LP",
+	"ContributedBy": "Michael Jendrysik",
+	"License": "MIT License",
+	"Purpose": "CSM Redfish Interoperability profile.",
+	"ContactInfo": "michael.jendrysik@hpe.com",
+	"RequiredProfiles": {
+	},
+	"Resources": {
+		"ManagerCollection": {
+			"PropertyRequirements": {
+				"Members": {
+					"MinCount": 1
+				}
+			}
+		},
+		"Manager": {
+			"ReadRequirement": "Mandatory",
+			"MinVersion": "1.3.2",
+			"ActionRequirements": {
+				"Reset": {
+					"ReadRequirement": "IfImplemented",
+					"Parameters": {
+						"ResetType": {
+							"ReadRequirement": "Mandatory",
+							"ParameterValues": [
+								"ForceRestart"
+							],
+							"RecommendedValues": [
+								"GracefulRestart"
+							]
+						}
+					}
+				}
+			},
+			"PropertyRequirements": {
+				"Name": {
+					"ReadRequirement": "Mandatory"
+				},
+				"NetworkProtocol": {
+					"ReadRequirement": "IfImplemented"
+				},
+				"Status": {
+					"PropertyRequirements": {
+						"State": {
+							"ReadRequirement": "IfImplemented"
+						},
+						"Health": {
+							"ReadRequirement": "Mandatory"
+						}
+					}
+				}
+			}
+		},
+		"ChassisCollection": {
+			"PropertyRequirements": {
+				"Members": {
+					"MinCount": 1
+				}
+			}
+		},
+		"Chassis": {
+			"ReadRequirement": "Mandatory",
+			"MinVersion": "1.5.1",
+			"PropertyRequirements": {
+				"SerialNumber": {
+					"ReadRequirement": "Recommended"
+				},
+				"Power": {
+					"ReadRequirement": "Recommended"
+				},
+				"Thermal": {
+					"ReadRequirement": "Recommended"
+				},
+				"Controls": {
+					"ReadRequirement": "Recommended"
+				},
+				"PartNumber": {
+					"ReadRequirement": "Recommended"
+				},
+				"Manufacturer": {
+					"ReadRequirement": "Mandatory"
+				},
+				"Model": {
+					"ReadRequirement": "Recommended"
+				},
+				"PowerState": {
+					"ReadRequirement": "Recommended"
+				},
+				"Status": {
+					"ReadRequirement": "IfImplemented",
+					"PropertyRequirements": {
+						"State": {
+							"ReadRequirement": "Mandatory"
+						},
+						"Health": {
+							"ReadRequirement": "Mandatory"
+						}
+					}
+				}
+			}
+		},
+		"ControlsCollection": {
+			"PropertyRequirements": {
+				"Members": {
+					"MinCount": 1
+				}
+			}
+		},
+		"Control": {
+			"MinVersion": "1.0.0",
+			"PropertyRequirements": {
+				"ControlMode":{
+					"ReadRequirement": "Recommended"
+				},
+				"ControlType":{
+					"ReadRequirement": "Recommended"
+				},
+				"Name": {
+					"ReadRequirement": "Mandatory"
+				},
+				"SetPoint": {
+					"WriteRequirement": "Mandatory"
+				},
+				"SettingRangeMax": {
+					"ReadRequirement": "Mandatory"
+				},
+				"SettingRangeMin": {
+					"ReadRequirement": "Mandatory"
+				},
+				"PhysicalContext": {
+					"ReadRequirement": "Mandatory"
+				},
+				"Sensor": {
+					"PropertyRequirements": {
+						"Reading": {
+							"ReadRequirement": "Mandatory"
+						}
+					}
+				}
+			}
+		},
+		"ComputerSystemCollection": {
+			"PropertyRequirements": {
+				"Members": {
+					"MinCount": 1
+				}
+			}
+		},
+		"ComputerSystem": {
+			"ReadRequirement": "Mandatory",
+			"MinVersion": "1.5.0",
+			"PropertyRequirements": {
+				"BiosVersion": {
+					"ReadRequirement": "IfImplemented"
+				},
+				"SerialNumber": {
+					"ReadRequirement": "Mandatory"
+				},
+				"Manufacturer": {
+					"ReadRequirement": "Mandatory"
+				},
+				"Model": {
+					"ReadRequirement": "Mandatory"
+				},
+				"Name": {
+					"ReadRequirement": "Mandatory"
+				},
+				"SKU": {
+					"ReadRequirement": "Recommended",
+					"ConditionalRequirements": [
+						{
+							"Purpose": "Either PartNumber or SKU must be supported.",
+							"CompareProperty": "PartNumber",
+							"CompareType": "Absent",
+							"ReadRequirement": "Mandatory"
+						}
+					]
+				},
+				"PartNumber": {
+					"ReadRequirement": "Recommended",
+					"ConditionalRequirements": [
+						{
+							"Purpose": "Either PartNumber or SKU must be supported.",
+							"CompareProperty": "SKU",
+							"CompareType": "Absent",
+							"ReadRequirement": "Mandatory"
+						}
+					]
+				},
+				"PowerState": {
+					"ReadRequirement": "Mandatory"
+				},
+				"Status": {
+					"PropertyRequirements": {
+						"State": {
+							"ReadRequirement": "Mandatory"
+						},
+						"Health": {
+							"ReadRequirement": "Mandatory"
+						}
+					}
+				},
+				"SystemType": {
+					"ReadRequirement": "Mandatory"
+				}
+			},
+			"ActionRequirements": {
+				"Reset": {
+					"ReadRequirement": "Mandatory",
+					"Purpose": "Ability to reset the system is a core requirement of most users.",
+					"Parameters": {
+						"ResetType": {
+							"ParameterValues": [
+								"On",
+								"ForceOff"
+							],
+							"RecommendedValues": [
+								"GracefulShutdown",
+								"GracefulRestart",
+								"ForceRestart",
+								"Nmi",
+								"PushPowerButton",
+								"Off"
+							],
+							"ReadRequirement": "Mandatory"
+						}
+					}
+				}
+			}
+		},
+		"MemoryCollection": {
+			"PropertyRequirements": {
+				"Members": {
+					"MinCount": 1
+				}
+			}
+		},
+		"Memory": {
+			"ReadRequirement": "Mandatory",
+			"MinVersion": "1.5.0",
+			"PropertyRequirements": {
+				"CapacityMiB": {
+					"ReadRequirement": "IfPopulated"
+				},
+				"Id": {
+					"ReadRequirement": "IfPopulated"
+				},
+				"MemoryDeviceType": {
+					"ReadRequirement": "Recommended"
+				},
+				"Manufacturer": {
+					"ReadRequirement": "IfPopulated"
+				},
+				"PartNumber": {
+					"ReadRequirement": "IfPopulated"
+				},
+				"SerialNumber": {
+					"ReadRequirement": "IfPopulated"
+				},
+				"OperatingSpeedMhz": {
+					"ReadRequirement": "IfPopulated"
+				}
+			}
+		},
+		"ProcessorCollection": {
+			"PropertyRequirements": {
+				"Members": {
+					"MinCount": 1
+				}
+			}
+		},
+		"Processor": {
+			"ReadRequirement": "Mandatory",
+			"MinVersion": "1.5.1",
+			"PropertyRequirements": {
+				"Manufacturer": {
+					"ReadRequirement": "Mandatory"
+				},
+				"Model": {
+					"ReadRequirement": "Mandatory"
+				},
+				"SerialNumber": {
+					"ReadRequirement": "Mandatory"
+				},
+				"TotalCores": {
+					"ReadRequirement": "IfImplemented"
+				},
+				"TotalThreads": {
+					"ReadRequirement": "IfImplemented"
+				},
+				"MaxSpeedMHz": {
+					"ReadRequirement": "IfImplemented"
+				},
+				"Status": {
+					"PropertyRequirements": {
+						"Health": {
+							"ReadRequirement": "Recommended"
+						}
+					}
+				},
+				"ProcessorType": {
+					"ReadRequirement": "Mandatory",
+					"Comparison": "Equal",
+					"Purpose": "At least one of the Processor entries needs to be a GPU",
+					"Values": [
+						"GPU"
+					]
+				}
+			}
+		},
+		"EthernetInterfaceCollection": {
+			"PropertyRequirements": {
+				"Members": {
+					"MinCount": 1
+				}
+			}
+		},
+		"EthernetInterface": {
+			"MinVersion": "1.3.0",
+			"PropertyRequirements": {
+				"Description": {
+					"ReadRequirement": "Recommended",
+					"ConditionalRequirements": [{
+						"SubordinateToResource": [
+							"Manager",
+							"EthernetInterfaceCollection"
+						],
+						"ReadRequirement": "Mandatory"
+					}]
+				},
+				"Id": {
+					"ReadRequirement": "Recommended",
+					"ConditionalRequirements": [{
+						"SubordinateToResource": [
+							"Manager",
+							"EthernetInterfaceCollection"
+						],
+						"ReadRequirement": "Mandatory"
+					}]
+				},
+				"InterfaceEnabled": {
+					"ReadRequirement": "Recommended",
+					"ConditionalRequirements": [{
+						"SubordinateToResource": [
+							"Manager",
+							"EthernetInterfaceCollection"
+						],
+						"ReadRequirement": "Mandatory"
+					}]
+				},
+				"MACAddress": {
+					"ReadRequirement": "Recommended",
+					"ConditionalRequirements": [{
+						"SubordinateToResource": [
+							"Manager",
+							"EthernetInterfaceCollection"
+						],
+						"ReadRequirement": "Mandatory"
+					}]
+				}
+			}
+		},
+		"HpeServerAccPowerLimit": {
+			"MinVersion": "1.0.0",
+			"PropertyRequirements": {
+				"ActualPowerLimits": {
+					"PropertyRequirements": {
+						"PowerLimitInWatts": {
+							"ReadRequirement": "Mandatory"
+						}
+					}
+				},
+				"PowerLimitRanges": {
+					"PropertyRequirements": {
+						"MaximumPowerLimit": {
+							"ReadRequirement": "Mandatory"
+						},
+						"MinimumPowerLimit": {
+							"ReadRequirement": "Mandatory"
+						}
+					}
+				},
+				"PowerLimits": {
+					"PropertyRequirements": {
+						"PowerLimitInWatts": {
+							"WriteRequirement": "Mandatory"
+						}
+					}
+				}
+			}
+		},
+		"Power": {
+			"MinVersion": "1.3.0",
+			"PropertyRequirements": {
+				"PowerControl": {
+					"ReadRequirement": "IfImplemented",
+					"PropertyRequirements": {
+						"PowerCapacityWatts": {
+							"ReadRequirement": "Recommended"
+						},
+						"PowerLimit": {
+							"ReadRequirement": "IfImplemented",
+							"PropertyRequirements": {
+								"LimitInWatts": {
+									"WriteRequirement": "IfImplemented"
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"EventService": {
+			"ReadRequirement": "Mandatory",
+			"MinVersion": "1.0.5",
+			"PropertyRequirements": {
+				"Subscriptions": {
+					"ReadRequirement": "Mandatory"
+				},
+				"EventTypesForSubscription": {
+					"ReadRequirement": "Mandatory"
+				}
+			}
+		},
+		"UpdateService": {
+			"ReadRequirement": "Mandatory",
+			"MinVersion": "1.1.1",
+			"ActionRequirements": {
+				"SimpleUpdate": {
+					"ReadRequirement": "Mandatory",
+					"Parameters": {
+						"TransferProtocol": {
+							"ParameterValues": [
+								"HTTPS"
+							],
+							"RecommendedValues": [
+								"HTTP"
+							]
+						}
+					}
+				}
+			},
+			"PropertyRequirements": {
+				"FirmwareInventory": {
+					"ReadRequirement": "Mandatory"
+				}
+			}
+		},
+		"SoftwareInventoryCollection": {
+			"PropertyRequirements": {
+				"Members": {
+					"MinCount": 1
+				}
+			}
+		},
+		"SoftwareInventory": {
+			"ReadRequirement": "Mandatory",
+			"MinVersion": "1.1.0",
+			"PropertyRequirements": {
+				"Id": {
+					"ReadRequirement": "Mandatory"
+				},
+				"Version": {
+					"ReadRequirement": "Mandatory"
+				},
+				"Name": {
+					"ReadRequirement": "Mandatory"
+				}
+			}
+		},
+		"ManagerNetworkProtocol": {
+			"MinVersion": "1.0.0",
+			"PropertyRequirements": {
+				"NTP": {
+					"ReadRequirement": "IfImplemented",
+					"PropertyRequirements": {
+						"NTPServers": {
+							"WriteRequirement": "IfImplemented"
+						},
+						"Port": {
+							"WriteRequirement": "IfImplemented"
+						}
+					}
+				},
+				"Oem": {
+					"ReadRequirement": "IfImplemented",
+					"PropertyRequirements": {
+						"SSHAdmin": {
+							"ReadRequirement": "IfImplemented",
+							"WriteRequirement": "IfImplemented"
+						},
+						"SSHConsole": {
+							"ReadRequirement": "IfImplemented",
+							"WriteRequirement": "IfImplemented"
+						},
+						"Syslog": {
+							"WriteRequirement": "IfImplemented",
+							"ReadRequirement": "IfImplemented",
+							"PropertyRequirements": {
+								"SyslogServers": {
+									"WriteRequirement": "IfImplemented"
+								},
+								"ProtocolEnabled": {
+									"WriteRequirement": "IfImplemented"
+								},
+								"Transport": {
+									"WriteRequirement": "IfImplemented"
+								},
+								"Port": {
+									"WriteRequirement": "IfImplemented"
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"ManagerAccountCollection:": {
+			"PropertyRequirements": {
+				"Members": {
+					"MinCount": 1
+				}
+			}
+		},
+		"ManagerAccount": {
+			"ReadRequirement": "Mandatory",
+			"MinVersion": "1.1.1",
+			"PropertyRequirements": {
+				"Password": {
+					"ReadRequirement": "None",
+					"WriteRequirement": "Mandatory"
+				},
+				"UserName": {
+					"WriteRequirement": "Mandatory"
+				}
+			}
+		},
+		"SessionService": {
+			"ReadRequirement": "Mandatory",
+			"MinVersion": "1.0.0",
+			"PropertyRequirements": {
+				"Sessions": {
+					"ReadRequirement": "Mandatory"
+				},
+				"SessionTimeout": {
+					"ReadRequirement": "IfImplemented"
+				},
+				"ServiceEnabled": {
+					"ReadRequirement": "Mandatory"
+				}
+			}
+		},
+		"TaskService": {
+			"ReadRequirement": "Mandatory",
+			"MinVersion": "1.1.0",
+			"PropertyRequirements": {
+				"Tasks": {
+					"ReadRequirement": "Mandatory"
+				},
+				"ServiceEnabled": {
+					"ReadRequirement": "Mandatory"
+				},
+				"LifeCycleEventOnTaskStateChange": {
+					"ReadRequirement": "Mandatory"
+				}
+			}
+		}
+	}
+}

--- a/profiles/CSMRedfishProfile.v1_2_0.json
+++ b/profiles/CSMRedfishProfile.v1_2_0.json
@@ -1,0 +1,565 @@
+{
+	"SchemaDefinition": "RedfishInteroperabilityProfile.v1_5_0",
+	"ProfileName": "CSMRedfishProfile",
+	"ProfileVersion": "1.2.0",
+	"OwningEntity": "Hewlet Packard Enterprise Development LP",
+	"ContributedBy": "Michael Jendrysik",
+	"License": "MIT License",
+	"Purpose": "CSM Redfish Interoperability profile.",
+	"ContactInfo": "michael.jendrysik@hpe.com",
+	"RequiredProfiles": {
+	},
+	"Resources": {
+		"ManagerCollection": {
+			"PropertyRequirements": {
+				"Members": {
+					"MinCount": 1
+				}
+			}
+		},
+		"Manager": {
+			"ReadRequirement": "Mandatory",
+			"MinVersion": "1.3.2",
+			"ActionRequirements": {
+				"Reset": {
+					"ReadRequirement": "IfImplemented",
+					"Parameters": {
+						"ResetType": {
+							"ReadRequirement": "Mandatory",
+							"ParameterValues": [
+								"ForceRestart"
+							],
+							"RecommendedValues": [
+								"GracefulRestart"
+							]
+						}
+					}
+				}
+			},
+			"PropertyRequirements": {
+				"Name": {
+					"ReadRequirement": "Mandatory"
+				},
+				"NetworkProtocol": {
+					"ReadRequirement": "IfImplemented"
+				},
+				"Status": {
+					"PropertyRequirements": {
+						"State": {
+							"ReadRequirement": "IfImplemented"
+						},
+						"Health": {
+							"ReadRequirement": "Mandatory"
+						}
+					}
+				}
+			}
+		},
+		"ChassisCollection": {
+			"PropertyRequirements": {
+				"Members": {
+					"MinCount": 1
+				}
+			}
+		},
+		"Chassis": {
+			"ReadRequirement": "Mandatory",
+			"MinVersion": "1.5.1",
+			"PropertyRequirements": {
+				"SerialNumber": {
+					"ReadRequirement": "Recommended"
+				},
+				"Power": {
+					"ReadRequirement": "Recommended"
+				},
+				"Thermal": {
+					"ReadRequirement": "Recommended"
+				},
+				"Controls": {
+					"ReadRequirement": "Recommended"
+				},
+				"PartNumber": {
+					"ReadRequirement": "Recommended"
+				},
+				"Manufacturer": {
+					"ReadRequirement": "Mandatory"
+				},
+				"Model": {
+					"ReadRequirement": "Recommended"
+				},
+				"PowerState": {
+					"ReadRequirement": "Recommended"
+				},
+				"Status": {
+					"ReadRequirement": "IfImplemented",
+					"PropertyRequirements": {
+						"State": {
+							"ReadRequirement": "Mandatory"
+						},
+						"Health": {
+							"ReadRequirement": "Mandatory"
+						}
+					}
+				}
+			}
+		},
+		"ControlsCollection": {
+			"PropertyRequirements": {
+				"Members": {
+					"MinCount": 1
+				}
+			}
+		},
+		"Control": {
+			"MinVersion": "1.0.0",
+			"PropertyRequirements": {
+				"ControlMode":{
+					"ReadRequirement": "Recommended"
+				},
+				"ControlType":{
+					"ReadRequirement": "Recommended"
+				},
+				"Name": {
+					"ReadRequirement": "Mandatory"
+				},
+				"SetPoint": {
+					"WriteRequirement": "Mandatory"
+				},
+				"SettingRangeMax": {
+					"ReadRequirement": "Mandatory"
+				},
+				"SettingRangeMin": {
+					"ReadRequirement": "Mandatory"
+				},
+				"PhysicalContext": {
+					"ReadRequirement": "Mandatory"
+				},
+				"Sensor": {
+					"PropertyRequirements": {
+						"Reading": {
+							"ReadRequirement": "Mandatory"
+						}
+					}
+				}
+			}
+		},
+		"ComputerSystemCollection": {
+			"PropertyRequirements": {
+				"Members": {
+					"MinCount": 1
+				}
+			}
+		},
+		"ComputerSystem": {
+			"ReadRequirement": "Mandatory",
+			"MinVersion": "1.5.0",
+			"PropertyRequirements": {
+				"BiosVersion": {
+					"ReadRequirement": "IfImplemented"
+				},
+				"SerialNumber": {
+					"ReadRequirement": "Mandatory"
+				},
+				"Manufacturer": {
+					"ReadRequirement": "Mandatory"
+				},
+				"Model": {
+					"ReadRequirement": "Mandatory"
+				},
+				"Name": {
+					"ReadRequirement": "Mandatory"
+				},
+				"SKU": {
+					"ReadRequirement": "Recommended",
+					"ConditionalRequirements": [
+						{
+							"Purpose": "Either PartNumber or SKU must be supported.",
+							"CompareProperty": "PartNumber",
+							"CompareType": "Absent",
+							"ReadRequirement": "Mandatory"
+						}
+					]
+				},
+				"PartNumber": {
+					"ReadRequirement": "Recommended",
+					"ConditionalRequirements": [
+						{
+							"Purpose": "Either PartNumber or SKU must be supported.",
+							"CompareProperty": "SKU",
+							"CompareType": "Absent",
+							"ReadRequirement": "Mandatory"
+						}
+					]
+				},
+				"PowerState": {
+					"ReadRequirement": "Mandatory"
+				},
+				"Status": {
+					"PropertyRequirements": {
+						"State": {
+							"ReadRequirement": "Mandatory"
+						},
+						"Health": {
+							"ReadRequirement": "Mandatory"
+						}
+					}
+				},
+				"SystemType": {
+					"ReadRequirement": "Mandatory"
+				}
+			},
+			"ActionRequirements": {
+				"Reset": {
+					"ReadRequirement": "Mandatory",
+					"Purpose": "Ability to reset the system is a core requirement of most users.",
+					"Parameters": {
+						"ResetType": {
+							"ParameterValues": [
+								"On",
+								"ForceOff"
+							],
+							"RecommendedValues": [
+								"GracefulShutdown",
+								"GracefulRestart",
+								"ForceRestart",
+								"Nmi",
+								"PushPowerButton",
+								"Off"
+							],
+							"ReadRequirement": "Mandatory"
+						}
+					}
+				}
+			}
+		},
+		"MemoryCollection": {
+			"PropertyRequirements": {
+				"Members": {
+					"MinCount": 1
+				}
+			}
+		},
+		"Memory": {
+			"ReadRequirement": "Mandatory",
+			"MinVersion": "1.5.0",
+			"PropertyRequirements": {
+				"CapacityMiB": {
+					"ReadRequirement": "IfPopulated"
+				},
+				"Id": {
+					"ReadRequirement": "IfPopulated"
+				},
+				"MemoryDeviceType": {
+					"ReadRequirement": "Recommended"
+				},
+				"Manufacturer": {
+					"ReadRequirement": "IfPopulated"
+				},
+				"PartNumber": {
+					"ReadRequirement": "IfPopulated"
+				},
+				"SerialNumber": {
+					"ReadRequirement": "IfPopulated"
+				},
+				"OperatingSpeedMhz": {
+					"ReadRequirement": "IfPopulated"
+				}
+			}
+		},
+		"ProcessorCollection": {
+			"PropertyRequirements": {
+				"Members": {
+					"MinCount": 1
+				}
+			}
+		},
+		"Processor": {
+			"ReadRequirement": "Mandatory",
+			"MinVersion": "1.5.1",
+			"PropertyRequirements": {
+				"Manufacturer": {
+					"ReadRequirement": "Mandatory"
+				},
+				"Model": {
+					"ReadRequirement": "Mandatory"
+				},
+				"SerialNumber": {
+					"ReadRequirement": "Mandatory"
+				},
+				"TotalCores": {
+					"ReadRequirement": "IfImplemented"
+				},
+				"TotalThreads": {
+					"ReadRequirement": "IfImplemented"
+				},
+				"MaxSpeedMHz": {
+					"ReadRequirement": "IfImplemented"
+				},
+				"Status": {
+					"PropertyRequirements": {
+						"Health": {
+							"ReadRequirement": "Recommended"
+						}
+					}
+				}
+			}
+		},
+		"EthernetInterfaceCollection": {
+			"PropertyRequirements": {
+				"Members": {
+					"MinCount": 1
+				}
+			}
+		},
+		"EthernetInterface": {
+			"MinVersion": "1.3.0",
+			"PropertyRequirements": {
+				"Description": {
+					"ReadRequirement": "Recommended",
+					"ConditionalRequirements": [{
+						"SubordinateToResource": [
+							"Manager",
+							"EthernetInterfaceCollection"
+						],
+						"ReadRequirement": "Mandatory"
+					}]
+				},
+				"Id": {
+					"ReadRequirement": "Recommended",
+					"ConditionalRequirements": [{
+						"SubordinateToResource": [
+							"Manager",
+							"EthernetInterfaceCollection"
+						],
+						"ReadRequirement": "Mandatory"
+					}]
+				},
+				"InterfaceEnabled": {
+					"ReadRequirement": "Recommended",
+					"ConditionalRequirements": [{
+						"SubordinateToResource": [
+							"Manager",
+							"EthernetInterfaceCollection"
+						],
+						"ReadRequirement": "Mandatory"
+					}]
+				},
+				"MACAddress": {
+					"ReadRequirement": "Recommended",
+					"ConditionalRequirements": [{
+						"SubordinateToResource": [
+							"Manager",
+							"EthernetInterfaceCollection"
+						],
+						"ReadRequirement": "Mandatory"
+					}]
+				}
+			}
+		},
+		"HpeServerAccPowerLimit": {
+			"MinVersion": "1.0.0",
+			"PropertyRequirements": {
+				"ActualPowerLimits": {
+					"PropertyRequirements": {
+						"PowerLimitInWatts": {
+							"ReadRequirement": "Mandatory"
+						}
+					}
+				},
+				"PowerLimitRanges": {
+					"PropertyRequirements": {
+						"MaximumPowerLimit": {
+							"ReadRequirement": "Mandatory"
+						},
+						"MinimumPowerLimit": {
+							"ReadRequirement": "Mandatory"
+						}
+					}
+				},
+				"PowerLimits": {
+					"PropertyRequirements": {
+						"PowerLimitInWatts": {
+							"WriteRequirement": "Mandatory"
+						}
+					}
+				}
+			}
+		},
+		"Power": {
+			"MinVersion": "1.3.0",
+			"PropertyRequirements": {
+				"PowerControl": {
+					"ReadRequirement": "IfImplemented",
+					"PropertyRequirements": {
+						"PowerCapacityWatts": {
+							"ReadRequirement": "Recommended"
+						},
+						"PowerLimit": {
+							"ReadRequirement": "IfImplemented",
+							"PropertyRequirements": {
+								"LimitInWatts": {
+									"WriteRequirement": "IfImplemented"
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"EventService": {
+			"ReadRequirement": "Mandatory",
+			"MinVersion": "1.0.5",
+			"PropertyRequirements": {
+				"Subscriptions": {
+					"ReadRequirement": "Mandatory"
+				},
+				"EventTypesForSubscription": {
+					"ReadRequirement": "Mandatory"
+				}
+			}
+		},
+		"UpdateService": {
+			"ReadRequirement": "Mandatory",
+			"MinVersion": "1.1.1",
+			"ActionRequirements": {
+				"SimpleUpdate": {
+					"ReadRequirement": "Mandatory",
+					"Parameters": {
+						"TransferProtocol": {
+							"ParameterValues": [
+								"HTTPS"
+							],
+							"RecommendedValues": [
+								"HTTP"
+							]
+						}
+					}
+				}
+			},
+			"PropertyRequirements": {
+				"FirmwareInventory": {
+					"ReadRequirement": "Mandatory"
+				}
+			}
+		},
+		"SoftwareInventoryCollection": {
+			"PropertyRequirements": {
+				"Members": {
+					"MinCount": 1
+				}
+			}
+		},
+		"SoftwareInventory": {
+			"ReadRequirement": "Mandatory",
+			"MinVersion": "1.1.0",
+			"PropertyRequirements": {
+				"Id": {
+					"ReadRequirement": "Mandatory"
+				},
+				"Version": {
+					"ReadRequirement": "Mandatory"
+				},
+				"Name": {
+					"ReadRequirement": "Mandatory"
+				}
+			}
+		},
+		"ManagerNetworkProtocol": {
+			"MinVersion": "1.0.0",
+			"PropertyRequirements": {
+				"NTP": {
+					"ReadRequirement": "IfImplemented",
+					"PropertyRequirements": {
+						"NTPServers": {
+							"WriteRequirement": "IfImplemented"
+						},
+						"Port": {
+							"WriteRequirement": "IfImplemented"
+						}
+					}
+				},
+				"Oem": {
+					"ReadRequirement": "IfImplemented",
+					"PropertyRequirements": {
+						"SSHAdmin": {
+							"ReadRequirement": "IfImplemented",
+							"WriteRequirement": "IfImplemented"
+						},
+						"SSHConsole": {
+							"ReadRequirement": "IfImplemented",
+							"WriteRequirement": "IfImplemented"
+						},
+						"Syslog": {
+							"WriteRequirement": "IfImplemented",
+							"ReadRequirement": "IfImplemented",
+							"PropertyRequirements": {
+								"SyslogServers": {
+									"WriteRequirement": "IfImplemented"
+								},
+								"ProtocolEnabled": {
+									"WriteRequirement": "IfImplemented"
+								},
+								"Transport": {
+									"WriteRequirement": "IfImplemented"
+								},
+								"Port": {
+									"WriteRequirement": "IfImplemented"
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"ManagerAccountCollection:": {
+			"PropertyRequirements": {
+				"Members": {
+					"MinCount": 1
+				}
+			}
+		},
+		"ManagerAccount": {
+			"ReadRequirement": "Mandatory",
+			"MinVersion": "1.1.1",
+			"PropertyRequirements": {
+				"Password": {
+					"ReadRequirement": "None",
+					"WriteRequirement": "Mandatory"
+				},
+				"UserName": {
+					"WriteRequirement": "Mandatory"
+				}
+			}
+		},
+		"SessionService": {
+			"ReadRequirement": "Mandatory",
+			"MinVersion": "1.0.0",
+			"PropertyRequirements": {
+				"Sessions": {
+					"ReadRequirement": "Mandatory"
+				},
+				"SessionTimeout": {
+					"ReadRequirement": "IfImplemented"
+				},
+				"ServiceEnabled": {
+					"ReadRequirement": "Mandatory"
+				}
+			}
+		},
+		"TaskService": {
+			"ReadRequirement": "Mandatory",
+			"MinVersion": "1.1.0",
+			"PropertyRequirements": {
+				"Tasks": {
+					"ReadRequirement": "Mandatory"
+				},
+				"ServiceEnabled": {
+					"ReadRequirement": "Mandatory"
+				},
+				"LifeCycleEventOnTaskStateChange": {
+					"ReadRequirement": "Mandatory"
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary and Scope
Created a new profile that checks to make sure there are GPUs in a system. Added some additional checks to standard profile as well.

- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct

## Issues and Related PRs

* Resolves CASMHMS-5494
* Resolves CASMHMS-5503

## Testing

### Tested on:

* `odin`

### Tested against:
* Cray Olympus Windom
* Cray Olympus Grizzly Peak

GPU profile successfully detected GPUs and non-GPUs.

## Risks and Mitigations

No known risks.